### PR TITLE
Habilitación de opción de esquema para las tablas de sara

### DIFF
--- a/blocks/development/codificador/formulario/codificador.php
+++ b/blocks/development/codificador/formulario/codificador.php
@@ -1,65 +1,64 @@
-<?php 
+<?php
 /**
  * IMPORTANTE: Este formulario está utilizando jquery. Por tanto en el archivo ready.php se delaran algunas funciones js
  * que lo complementan. La variable $_REQUEST['tiempo'] se declara en dicho archivo ya que es el primero que se procesa. 
  */
-
+$_REQUEST ['tiempo'] = time ();
 // Rescatar los datos de este bloque
 $esteBloque = $this->miConfigurador->getVariableConfiguracion ( "esteBloque" );
 
 // ---------------- SECCION: Parámetros Globales del Formulario ----------------------------------
 /**
- * Atributos que deben ser aplicados a todos los controles de este formulario. Se utiliza un arreglo
+ * Atributos que deben ser aplicados a todos los controles de este formulario.
+ * Se utiliza un arreglo
  * independiente debido a que los atributos individuales se reinician cada vez que se declara un campo.
- * 
+ *
  * Si se utiliza esta técnica es necesario realizar un mezcla entre este arreglo y el específico en cada control:
- * $atributos=  array_merge($atributos,$atributosGlobales);
- * 
- * 
+ * $atributos= array_merge($atributos,$atributosGlobales);
  */
-$atributosGlobales['campoSeguro']='true';
+$atributosGlobales ['campoSeguro'] = 'true';
 
-//-------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 
 // ---------------- SECCION: Parámetros Generales del Formulario ----------------------------------
-$esteCampo=$esteBloque ['nombre'];
-$atributos['id']=$esteCampo;
-$atributos['nombre']=$esteCampo;
-//Si no se coloca, entonces toma el valor predeterminado 'application/x-www-form-urlencoded'
-$atributos['tipoFormulario']='';
-//Si no se coloca, entonces toma el valor predeterminado 'POST'
-$atributos['metodo']='POST';
-//Si no se coloca, entonces toma el valor predeterminado 'index.php' (Recomendado)
-$atributos['action']='index.php';
-$atributos['titulo']=$this->lenguaje->getCadena($esteCampo);
-//Si no se coloca, entonces toma el valor predeterminado.
-$atributos['estilo']='';
-$atributos['marco']=true;
-$tab=1;
+$esteCampo = $esteBloque ['nombre'];
+$atributos ['id'] = $esteCampo;
+$atributos ['nombre'] = $esteCampo;
+// Si no se coloca, entonces toma el valor predeterminado 'application/x-www-form-urlencoded'
+$atributos ['tipoFormulario'] = '';
+// Si no se coloca, entonces toma el valor predeterminado 'POST'
+$atributos ['metodo'] = 'POST';
+// Si no se coloca, entonces toma el valor predeterminado 'index.php' (Recomendado)
+$atributos ['action'] = 'index.php';
+$atributos ['titulo'] = $this->lenguaje->getCadena ( $esteCampo );
+// Si no se coloca, entonces toma el valor predeterminado.
+$atributos ['estilo'] = '';
+$atributos ['marco'] = true;
+$tab = 1;
 // ---------------- FIN SECCION: de Parámetros Generales del Formulario ----------------------------
 
-//----------------INICIAR EL FORMULARIO ------------------------------------------------------------
-$atributos['tipoEtiqueta']='inicio';
-echo $this->miFormulario->formulario($atributos);
+// ----------------INICIAR EL FORMULARIO ------------------------------------------------------------
+$atributos ['tipoEtiqueta'] = 'inicio';
+echo $this->miFormulario->formulario ( $atributos );
 
-//---------------- SECCION: Controles del Formulario -----------------------------------------------
+// ---------------- SECCION: Controles del Formulario -----------------------------------------------
 
-//---------------- CONTROL: Cuadro de Texto -------------------------------------------------------- 
-$esteCampo='campoCadena';
-$atributos['id']=$esteCampo;
-$atributos['nombre']=$esteCampo;
-$atributos['estilo']='jqueryui';
-$atributos['columnas']=100;
-$atributos['filas']=10;
-$atributos['tabIndex']=$tab;
-$atributos['etiqueta']= $this->lenguaje->getCadena($esteCampo);
-$atributos['titulo']=$this->lenguaje->getCadena($esteCampo.'Titulo');
-$atributos['deshabilitado']=false;
-$tab++;
+// ---------------- CONTROL: Cuadro de Texto --------------------------------------------------------
+$esteCampo = 'campoCadena';
+$atributos ['id'] = $esteCampo;
+$atributos ['nombre'] = $esteCampo;
+$atributos ['estilo'] = 'jqueryui';
+$atributos ['columnas'] = 100;
+$atributos ['filas'] = 10;
+$atributos ['tabIndex'] = $tab;
+$atributos ['etiqueta'] = $this->lenguaje->getCadena ( $esteCampo );
+$atributos ['titulo'] = $this->lenguaje->getCadena ( $esteCampo . 'Titulo' );
+$atributos ['deshabilitado'] = false;
+$tab ++;
 
-//Aplica atributos globales al control
-$atributos=  array_merge($atributos,$atributosGlobales);
-echo $this->miFormulario->campoTextArea($atributos);
+// Aplica atributos globales al control
+$atributos = array_merge ( $atributos, $atributosGlobales );
+echo $this->miFormulario->campoTextArea ( $atributos );
 // --------------- FIN CONTROL : Cuadro de Texto --------------------------------------------------
 
 // ------------------Division para los botones-------------------------
@@ -67,34 +66,12 @@ $atributos ["id"] = "botones";
 $atributos ["estilo"] = "marcoBotones";
 echo $this->miFormulario->division ( "inicio", $atributos );
 
-
-//-----------------CONTROL: Botón  ----------------------------------------------------------------
+// -----------------CONTROL: Botón ----------------------------------------------------------------
 $esteCampo = 'botonCodificar';
 $atributos ["id"] = $esteCampo;
 $atributos ["tabIndex"] = $tab;
 $atributos ["tipo"] = 'boton';
-//submit: no se coloca si se desea un tipo button genérico
-$atributos ['submit'] = true; 
-$atributos ["estiloMarco"] = '';
-$atributos ["estiloBoton"] = 'jqueryui';
-// verificar: true para verificar el formulario antes de pasarlo al servidor.
-$atributos ["verificar"] = ''; 
-$atributos ["tipoSubmit"] = 'jquery'; // Dejar vacio para un submit normal, en este caso se ejecuta la función submit declarada en ready.js
-$atributos ["valor"] = $this->lenguaje->getCadena ( $esteCampo );
-$atributos ['nombreFormulario'] = $esteBloque ['nombre'];
-$tab++;
-
-//Aplica atributos globales al control
-$atributos=  array_merge($atributos,$atributosGlobales);
-echo $this->miFormulario->campoBoton ( $atributos );
-//-----------------FIN CONTROL: Botón  -----------------------------------------------------------
-
-//-----------------CONTROL: Botón  ----------------------------------------------------------------
-$esteCampo = 'botonDecodificar';
-$atributos ["id"] = $esteCampo;
-$atributos ["tabIndex"] = $tab;
-$atributos ["tipo"] = 'boton';
-//submit: no se coloca si se desea un tipo button genérico
+// submit: no se coloca si se desea un tipo button genérico
 $atributos ['submit'] = true;
 $atributos ["estiloMarco"] = '';
 $atributos ["estiloBoton"] = 'jqueryui';
@@ -103,21 +80,42 @@ $atributos ["verificar"] = '';
 $atributos ["tipoSubmit"] = 'jquery'; // Dejar vacio para un submit normal, en este caso se ejecuta la función submit declarada en ready.js
 $atributos ["valor"] = $this->lenguaje->getCadena ( $esteCampo );
 $atributos ['nombreFormulario'] = $esteBloque ['nombre'];
-$tab++;
+$tab ++;
 
-//Aplica atributos globales al control
-$atributos=  array_merge($atributos,$atributosGlobales);
+// Aplica atributos globales al control
+$atributos = array_merge ( $atributos, $atributosGlobales );
 echo $this->miFormulario->campoBoton ( $atributos );
-//-----------------FIN CONTROL: Botón  -----------------------------------------------------------
+// -----------------FIN CONTROL: Botón -----------------------------------------------------------
+
+// -----------------CONTROL: Botón ----------------------------------------------------------------
+$esteCampo = 'botonDecodificar';
+$atributos ["id"] = $esteCampo;
+$atributos ["tabIndex"] = $tab;
+$atributos ["tipo"] = 'boton';
+// submit: no se coloca si se desea un tipo button genérico
+$atributos ['submit'] = true;
+$atributos ["estiloMarco"] = '';
+$atributos ["estiloBoton"] = 'jqueryui';
+// verificar: true para verificar el formulario antes de pasarlo al servidor.
+$atributos ["verificar"] = '';
+$atributos ["tipoSubmit"] = 'jquery'; // Dejar vacio para un submit normal, en este caso se ejecuta la función submit declarada en ready.js
+$atributos ["valor"] = $this->lenguaje->getCadena ( $esteCampo );
+$atributos ['nombreFormulario'] = $esteBloque ['nombre'];
+$tab ++;
+
+// Aplica atributos globales al control
+$atributos = array_merge ( $atributos, $atributosGlobales );
+echo $this->miFormulario->campoBoton ( $atributos );
+// -----------------FIN CONTROL: Botón -----------------------------------------------------------
 
 // ------------------Fin Division para los botones-------------------------
 echo $this->miFormulario->division ( "fin" );
 
-
 // ------------------- SECCION: Paso de variables ------------------------------------------------
 
 /**
- * En algunas ocasiones es útil pasar variables entre las diferentes páginas. SARA permite realizar esto a través de tres
+ * En algunas ocasiones es útil pasar variables entre las diferentes páginas.
+ * SARA permite realizar esto a través de tres
  * mecanismos:
  * (a). Registrando las variables como variables de sesión. Estarán disponibles durante toda la sesión de usuario. Requiere acceso a
  * la base de datos.
@@ -126,29 +124,33 @@ echo $this->miFormulario->division ( "fin" );
  * (c) a través de campos ocultos en los formularios. (deprecated)
  */
 
-//En este formulario se utiliza el mecanismo (b) para pasar las siguientes variables:
+// En este formulario se utiliza el mecanismo (b) para pasar las siguientes variables:
 
 // Paso 1: crear el listado de variables
 $valorCodificado = "actionBloque=" . $esteBloque ["nombre"];
-$valorCodificado .= "&pagina=" . $this->miConfigurador->getVariableConfiguracion('pagina');
+$valorCodificado .= "&pagina=" . $this->miConfigurador->getVariableConfiguracion ( 'pagina' );
 $valorCodificado .= "&bloque=" . $esteBloque ["id_bloque"];
 $valorCodificado .= "&bloqueGrupo=" . $esteBloque ["grupo"];
 /**
- * SARA permite que los nombres de los campos sean dinámicos. Para ello utiliza la hora en que es creado el formulario para
+ * SARA permite que los nombres de los campos sean dinámicos.
+ * Para ello utiliza la hora en que es creado el formulario para
  * codificar el nombre de cada campo. Si se utiliza esta técnica es necesario pasar dicho tiempo como una variable:
  * (a) invocando a la variable $_REQUEST ['tiempo'] que se ha declarado en ready.php o
  * (b) asociando el tiempo en que se está creando el formulario
- */ 
+ */
 $valorCodificado .= "&tiempo=" . $_REQUEST ['tiempo'];
-//Paso 2: codificar la cadena resultante
+/**
+ * Se agrega el 'campoSeguro' para que la variable $_REQUEST llegue decodificada a la función codificador.php
+ */
+$valorCodificado .= "&campoSeguro=" . $_REQUEST ['tiempo'];
+// Paso 2: codificar la cadena resultante
 $valorCodificado = $this->miConfigurador->fabricaConexiones->crypto->codificar ( $valorCodificado );
-
 
 $atributos ["id"] = "formSaraData"; // No cambiar este nombre
 $atributos ["tipo"] = "hidden";
-$atributos ['estilo']='';
+$atributos ['estilo'] = '';
 $atributos ["obligatorio"] = false;
-$atributos ['marco']=true;
+$atributos ['marco'] = true;
 $atributos ["etiqueta"] = "";
 $atributos ["valor"] = $valorCodificado;
 echo $this->miFormulario->campoCuadroTexto ( $atributos );
@@ -163,10 +165,6 @@ unset ( $atributos );
 $atributos ['marco'] = true;
 $atributos ['tipoEtiqueta'] = 'fin';
 echo $this->miFormulario->formulario ( $atributos );
-
-
-
-
 
 ?>
 

--- a/config/ArchivoConfiguracion.class.php
+++ b/config/ArchivoConfiguracion.class.php
@@ -23,108 +23,89 @@
  *      
  */
 class ArchivoConfiguracion {
-    
-    private static $instance;
-    
-    /**
-     * Contiene los datos básicos de acceso a la base de datos principal del
-     * framework.
-     * Este usuario debe tener solo permisos de lectura.
-     *
-     * @var string[]
-     */
-    var $conf;
-    
-    var $ruta;
-    
-    private function __construct() {
-        
-        $this->conf = array ();    
-    }
-    
-    public static function singleton() {
-        
-        if (! isset ( self::$instance )) {
-            $className = __CLASS__;
-            self::$instance = new $className ();
-        }
-        return self::$instance;
-    
-    }
-    
-    public function setConectorDB($objeto) {
-        
-        $this->fabricaConexiones = $objeto;
-    
-    }
-    
-    function getConf() {
-        
-        return $this->conf;
-    
-    }
-    
-    /**
-     * Rescata las variables de configuración que se encuentran en config.inc.php y
-     * en la base de datos principal (cuyos datos de conexión están en config.inc.php).
-     * Los datos son cargados en el arreglo $configuracion
-     *
-     * @param
-     *            Ninguno
-     * @return number
-     */
-    function variable() {
-        
-        require_once ($this->ruta . "crypto/Encriptador.class.php");
-        require_once ($this->ruta . "crypto/aes.class.php");
-        require_once ($this->ruta . "crypto/aesctr.class.php");
-        
-        $this->cripto = Encriptador::singleton ();
-        $this->abrirArchivoConfiguracion ();
-        return 0;
-    
-    }
-    
-    function setRuta($valor) {
-        $this->ruta = $valor;
-        return true;
-    }
-    
-    private function abrirArchivoConfiguracion($ruta = "") {
-        
-        $respuesta=false;
-        if ($ruta == '') {
-            $ruta = 'config/';
-        }
-        
-        $fp = fopen ( $ruta . 'config.inc.php', "r" );
-        if ($fp) {
-            
-            $i = 0;
-            while ( ! feof ( $fp ) && $i < 9 ) {
-                $linea [$i] = $this->cripto->decodificar ( fgets ( $fp, 4096 ), "" );
-                $i ++;
-            }
-            
-            fclose ( $fp );
-            
-            if($i>8){
-            
-            $this->conf ["dbsys"] = $linea [2];
-            $this->conf ["dbdns"] = $linea [3];
-            $this->conf ["dbpuerto"] = $linea [4];
-            $this->conf ["dbnombre"] = $linea [5];
-            $this->conf ["dbusuario"] = $linea [6];
-            $this->conf ["dbclave"] = $linea [7];
-            $this->conf ["dbprefijo"] = $linea [8];
-            
-            $respuesta=true;
-            }
-        }
-        
-        return $respuesta;
-    
-    }
-
+	private static $instance;
+	
+	/**
+	 * Contiene los datos básicos de acceso a la base de datos principal del
+	 * framework.
+	 * Este usuario debe tener solo permisos de lectura.
+	 *
+	 * @var string[]
+	 */
+	var $conf;
+	var $ruta;
+	private function __construct() {
+		$this->conf = array ();
+	}
+	public static function singleton() {
+		if (! isset ( self::$instance )) {
+			$className = __CLASS__;
+			self::$instance = new $className ();
+		}
+		return self::$instance;
+	}
+	public function setConectorDB($objeto) {
+		$this->fabricaConexiones = $objeto;
+	}
+	function getConf() {
+		return $this->conf;
+	}
+	
+	/**
+	 * Rescata las variables de configuración que se encuentran en config.inc.php y
+	 * en la base de datos principal (cuyos datos de conexión están en config.inc.php).
+	 * Los datos son cargados en el arreglo $configuracion
+	 *
+	 * @param
+	 *        	Ninguno
+	 * @return number
+	 */
+	function variable() {
+		require_once ($this->ruta . "crypto/Encriptador.class.php");
+		require_once ($this->ruta . "crypto/aes.class.php");
+		require_once ($this->ruta . "crypto/aesctr.class.php");
+		
+		$this->cripto = Encriptador::singleton ();
+		$this->abrirArchivoConfiguracion ();
+		return 0;
+	}
+	function setRuta($valor) {
+		$this->ruta = $valor;
+		return true;
+	}
+	private function abrirArchivoConfiguracion($ruta = "") {
+		$respuesta = false;
+		if ($ruta == '') {
+			$ruta = 'config/';
+		}
+		
+		$fp = fopen ( $ruta . 'config.inc.php', "r" );
+		if ($fp) {
+			
+			$i = 0;
+			while ( ! feof ( $fp ) && $i < 10 ) {
+				$linea [$i] = $this->cripto->decodificar ( fgets ( $fp, 4096 ), "" );
+				$i ++;
+			}
+			
+			fclose ( $fp );
+			
+			if ($i > 9) {
+				
+				$this->conf ["dbsys"] = $linea [2];
+				$this->conf ["dbdns"] = $linea [3];
+				$this->conf ["dbpuerto"] = $linea [4];
+				$this->conf ["dbnombre"] = $linea [5];
+				$this->conf ["dbusuario"] = $linea [6];
+				$this->conf ["dbclave"] = $linea [7];
+				$this->conf ["dbprefijo"] = $linea [8];
+				$this->conf ["dbesquema"] = $linea [9];
+				
+				$respuesta = true;
+			}
+		}
+		
+		return $respuesta;
+	}
 }
 ?>


### PR DESCRIPTION
Se presentaba el problema de que SARA no detectaba la instalación cuando se realizaba en un esquema de base de datos diferente al public.

La base de datos con que se probó fue en POSTGRESQL.

El problema es que no se leía de manera adecuada la variable "dbesquema" que se guardaba codificado en el archivo "config.inc.php".
