### PR TITLE
Solución de problema de funcion getRecursoDB cuando sara se instala en un esquema diferente al public en postgresql

### DIFF
--- a/core/connection/FabricaDbConexion.class.php
+++ b/core/connection/FabricaDbConexion.class.php
@@ -153,6 +153,11 @@ class FabricaDbConexion {
                            password as dbclave, 
                            dbms as dbsys ';
             $cadenaSql .= "FROM ";
+			$esquema = '';
+			if($this->configuracion ["dbesquema"]!=''){
+				$esquema = $this->configuracion ["dbesquema"] . '.';
+			}
+            $cadenaSql .= $esquema . $this->configuracion ["dbprefijo"] . "dbms ";
             $cadenaSql .= $this->configuracion ["dbprefijo"] . "dbms ";
             $cadenaSql .= "WHERE ";
             return $cadenaSql .= "nombre='" . $variable . "'";

--- a/core/connection/FabricaDbConexion.class.php
+++ b/core/connection/FabricaDbConexion.class.php
@@ -21,129 +21,129 @@ require_once ("core/crypto/Encriptador.class.php");
 require_once ("core/locale/Lenguaje.class.php");
 
 class FabricaDbConexion {
-    
-    private $configuracion;
-    
-    public $crypto;
-    
-    private $misConexiones;
-    
-    public $miLenguaje;
-    
-    private static $instance;
-    
-    const CONFIGURACION='configuracion';
-    
-    public static function singleton() {
-        
-        if (! isset ( self::$instance )) {
-            $className = __CLASS__;
-            self::$instance = new $className ();
-        }
-        return self::$instance;
-    
-    }
-    
-    private function __construct() {
-        
-        $this->crypto = Encriptador::singleton ();
-        
-        /**
-         * De forma predeterminadalos mensajes de error definidos en la clase
-         * se presentan en español
-         */
-        $this->miLenguaje = Lenguaje::singleton ();
-        $this->misConexiones = array ();
-    
-    }
-    
-    /**
-     * Método.
-     * Se encarga de crear un objeto para gestionar la conexión a un recurso
-     * de bases de datos dado. Los recursos pueden estar registrados en dos sitios:
-     * (a) en el archivo config.class.php, cuyos datos se gestionan por un objeto de
-     * la clase configurador (configuracion).
-     * (b) en la tabla dbms (tabla).
-     *
-     * De forma predeterminada se buscan los datos en la tabla.
-     *
-     * @param string $nombre            
-     * @return boolean dbms
-     */
-    public function setRecursoDB($nombre = "", $fuente = "tabla") {
-        
-        if ($nombre == "") {
-            $nombre = self::CONFIGURACION;
-        }
-        
-        switch ($fuente) {
-            
-            case self::CONFIGURACION :
-            case "instalacion" :
-                return $this->recursoConfiguracion ( $nombre );
-                break;
-            
-            default :
-                return $this->recursoTabla ( $nombre );
-                break;
-        }
-    
-    }
-    
-    /**
-     * Método.
-     * Encargado de crear los recursos de acceso a las bases de datos y
-     * agregarlos al arreglo de conexiones.
-     *
-     * @return boolean
-     */
-    private function recursoConfiguracion($nombre, $registro = "") {
-        
-        if ($registro == '') {
-            $gestorDb = new Dbms ( $this->configuracion );
-            
-        } else {
-        	$gestorDb = new Dbms ( $registro );
-        	
-        }
-        $recurso = $gestorDb->getRecursoDb ();
-        
-        if ($recurso && ! isset ( $this->misConexiones [$nombre] )) {
-            $this->misConexiones [$nombre] = $recurso;
-            return true;
-        }
-        
-        error_log ( $this->miLenguaje->getCadena ( "noInstanciaDatos" ) );
-        return false;
-    
-    }
-    
-    private function recursoTabla($nombre) {
-        
-        $recursoDB = $this->getRecursoDB (self::CONFIGURACION);
-        $cadena = $this->getClausulaSQL ( $nombre );
-        
-        $resultado = $recursoDB->ejecutarAcceso ( $cadena, "busqueda" );
-        
-        if (is_array ( $resultado )) {
-            foreach ( $resultado [0] as $clave => $valor ) {
-                $resultado [0] [$clave] = trim ( $valor );
-            }
-            
-            $resultado [0] ["dbclave"] = $this->crypto->decodificar ( $resultado [0] ["dbclave"] );
-            $resultado [0] [6] = $this->crypto->decodificar ( trim ( $resultado [0] [6] ) );
-            return $this->recursoConfiguracion ( $nombre, $resultado );
-        }
-        return false;
-    
-    }
-    
-    private function getClausulaSQL($variable) {
-        
-        if (isset ( $this->configuracion ["dbprefijo"] )) {
-            
-            $cadenaSql = "SELECT ";
-            $cadenaSql .= 'nombre,  
+
+	private $configuracion;
+
+	public $crypto;
+
+	private $misConexiones;
+
+	public $miLenguaje;
+
+	private static $instance;
+
+	const CONFIGURACION = 'configuracion';
+
+	public static function singleton() {
+
+		if (!isset(self::$instance)) {
+			$className = __CLASS__;
+			self::$instance = new $className();
+		}
+		return self::$instance;
+
+	}
+
+	private function __construct() {
+
+		$this -> crypto = Encriptador::singleton();
+
+		/**
+		 * De forma predeterminadalos mensajes de error definidos en la clase
+		 * se presentan en español
+		 */
+		$this -> miLenguaje = Lenguaje::singleton();
+		$this -> misConexiones = array();
+
+	}
+
+	/**
+	 * Método.
+	 * Se encarga de crear un objeto para gestionar la conexión a un recurso
+	 * de bases de datos dado. Los recursos pueden estar registrados en dos sitios:
+	 * (a) en el archivo config.class.php, cuyos datos se gestionan por un objeto de
+	 * la clase configurador (configuracion).
+	 * (b) en la tabla dbms (tabla).
+	 *
+	 * De forma predeterminada se buscan los datos en la tabla.
+	 *
+	 * @param string $nombre
+	 * @return boolean dbms
+	 */
+	public function setRecursoDB($nombre = "", $fuente = "tabla") {
+
+		if ($nombre == "") {
+			$nombre = self::CONFIGURACION;
+		}
+
+		switch ($fuente) {
+
+			case self::CONFIGURACION :
+			case "instalacion" :
+				return $this -> recursoConfiguracion($nombre);
+				break;
+
+			default :
+				return $this -> recursoTabla($nombre);
+				break;
+		}
+
+	}
+
+	/**
+	 * Método.
+	 * Encargado de crear los recursos de acceso a las bases de datos y
+	 * agregarlos al arreglo de conexiones.
+	 *
+	 * @return boolean
+	 */
+	private function recursoConfiguracion($nombre, $registro = "") {
+
+		if ($registro == '') {
+			$gestorDb = new Dbms($this -> configuracion);
+
+		} else {
+			$gestorDb = new Dbms($registro);
+
+		}
+		$recurso = $gestorDb -> getRecursoDb();
+
+		if ($recurso && !isset($this -> misConexiones[$nombre])) {
+			$this -> misConexiones[$nombre] = $recurso;
+			return true;
+		}
+
+		error_log($this -> miLenguaje -> getCadena("noInstanciaDatos"));
+		return false;
+
+	}
+
+	private function recursoTabla($nombre) {
+
+		$recursoDB = $this -> getRecursoDB(self::CONFIGURACION);
+		$cadena = $this -> getClausulaSQL($nombre);
+
+		$resultado = $recursoDB -> ejecutarAcceso($cadena, "busqueda");
+
+		if (is_array($resultado)) {
+			foreach ($resultado [0] as $clave => $valor) {
+				$resultado[0][$clave] = trim($valor);
+			}
+
+			$resultado[0]["dbclave"] = $this -> crypto -> decodificar($resultado[0]["dbclave"]);
+			$resultado[0][6] = $this -> crypto -> decodificar(trim($resultado[0][6]));
+			return $this -> recursoConfiguracion($nombre, $resultado);
+		}
+		return false;
+
+	}
+
+	private function getClausulaSQL($variable) {
+
+		if (isset($this -> configuracion["dbprefijo"])) {
+
+			$cadenaSql = "SELECT ";
+			$cadenaSql .= 'nombre,  
                            servidor as dbdns, 
                            puerto as dbpuerto, 
                            conexionssh as dbssl, 
@@ -152,56 +152,56 @@ class FabricaDbConexion {
                            usuario as dbusuario, 
                            password as dbclave, 
                            dbms as dbsys ';
-            $cadenaSql .= "FROM ";
+			$cadenaSql .= "FROM ";
 			$esquema = '';
-				if($this->configuracion ["dbesquema"]!=''){
-				$esquema = $this->configuracion ["dbesquema"] . '.';
+			if ($this -> configuracion["dbesquema"] != '') {
+				$esquema = $this -> configuracion["dbesquema"] . '.';
 			}
-            $cadenaSql .= $esquema . $this->configuracion ["dbprefijo"] . "dbms ";
-            $cadenaSql .= "WHERE ";
-            return $cadenaSql .= "nombre='" . $variable . "'";
-        
-        }
-        
-        return false;
-    
-    }
-    
-    /**
-     * Método de acceso.
-     *
-     * @param unknown $configuracion            
-     */
-    public function setConfiguracion($configuracion) {
-        
-        $this->configuracion = $configuracion;
-        return true;
-    
-    }
-    
-    /**
-     * Método de Acceso
-     *
-     * @param string $name            
-     * @return NULL
-     */
-    public function getRecursoDB($name) {
-        
-        if (isset ( $this->misConexiones [$name] )) {
-            return $this->misConexiones [$name];
-        } else {
-            
-            // Trata de crear la conexiòn
-            $this->setRecursoDB ( $name, 'tabla' );
-            
-            if (isset ( $this->misConexiones [$name] )) {
-                return $this->misConexiones [$name];
-            }
-            
-            return false;
-        }
-    
-    }
+			$cadenaSql .= $this -> configuracion["dbprefijo"] . "dbms ";
+			$cadenaSql .= "WHERE ";
+			return $cadenaSql .= "nombre='" . $variable . "'";
+
+		}
+
+		return false;
+
+	}
+
+	/**
+	 * Método de acceso.
+	 *
+	 * @param unknown $configuracion
+	 */
+	public function setConfiguracion($configuracion) {
+
+		$this -> configuracion = $configuracion;
+		return true;
+
+	}
+
+	/**
+	 * Método de Acceso
+	 *
+	 * @param string $name
+	 * @return NULL
+	 */
+	public function getRecursoDB($name) {
+
+		if (isset($this -> misConexiones[$name])) {
+			return $this -> misConexiones[$name];
+		} else {
+
+			// Trata de crear la conexiòn
+			$this -> setRecursoDB($name, 'tabla');
+
+			if (isset($this -> misConexiones[$name])) {
+				return $this -> misConexiones[$name];
+			}
+
+			return false;
+		}
+
+	}
 
 }
 ?>

--- a/core/connection/FabricaDbConexion.class.php
+++ b/core/connection/FabricaDbConexion.class.php
@@ -157,7 +157,7 @@ class FabricaDbConexion {
 			if ($this -> configuracion["dbesquema"] != '') {
 				$esquema = $this -> configuracion["dbesquema"] . '.';
 			}
-			$cadenaSql .= $this -> configuracion["dbprefijo"] . "dbms ";
+			$cadenaSql .= $esquema . $this -> configuracion["dbprefijo"] . "dbms ";
 			$cadenaSql .= "WHERE ";
 			return $cadenaSql .= "nombre='" . $variable . "'";
 

--- a/core/connection/FabricaDbConexion.class.php
+++ b/core/connection/FabricaDbConexion.class.php
@@ -154,11 +154,10 @@ class FabricaDbConexion {
                            dbms as dbsys ';
             $cadenaSql .= "FROM ";
 			$esquema = '';
-			if($this->configuracion ["dbesquema"]!=''){
+				if($this->configuracion ["dbesquema"]!=''){
 				$esquema = $this->configuracion ["dbesquema"] . '.';
 			}
             $cadenaSql .= $esquema . $this->configuracion ["dbprefijo"] . "dbms ";
-            $cadenaSql .= $this->configuracion ["dbprefijo"] . "dbms ";
             $cadenaSql .= "WHERE ";
             return $cadenaSql .= "nombre='" . $variable . "'";
         


### PR DESCRIPTION
Para buscar los datos de conexión en la tabla "DBMS" se realizaba una cadena SQL del estilo:
```sql
SELECT 
nombre,  
servidor as dbdns, 
puerto as dbpuerto, 
conexionssh as dbssl, 
 db as dbnombre, 
esquema as dbesquema, 
usuario as dbusuario, 
password as dbclave, 
dbms as dbsys 
FROM
app_dbms
WHERE nombre = 'nombreconexion'
```
Se agregó unas líneas en el archivo para que en caso de tener una instancia del framework SARA un esquema diferente al public, se ejecutara buscando el recurso incluyendo el esquema. El cadena SQL anterior se cambiaría entonces por:
```sql
SELECT 
nombre,  
servidor as dbdns, 
puerto as dbpuerto, 
conexionssh as dbssl, 
 db as dbnombre, 
esquema as dbesquema, 
usuario as dbusuario, 
password as dbclave, 
dbms as dbsys 
FROM
esquema.app_dbms -- Aquí se realizó el cambio
WHERE nombre = 'nombreconexion'
```